### PR TITLE
no warning was shown

### DIFF
--- a/src/bjdecomposition.jl
+++ b/src/bjdecomposition.jl
@@ -111,7 +111,7 @@ function create_cstrs_decomposition_list(m::JuMP.Model, A)
       if is_genericcstr(m, row_id) #Is it a generic constraint ?
         sp_type = :ALL
       elseif DW_dec_f != nothing # Dantzig-Wolfe decomposition
-        if name == :anonymous
+        if name == :anonymous_cstr
           warn("Anonymous constraint assigned to master problem during decomposition.")
           sp_type = :DW_MASTER
         else


### PR DESCRIPTION
We had changed name of anonymous constraints to anonymous_cstr but did not change it in the if condition to show a warning message when applying decomposition. 