### PR TITLE
Gen branching rules

### DIFF
--- a/docs/src/BlockSolverInterface.md
+++ b/docs/src/BlockSolverInterface.md
@@ -42,6 +42,10 @@ BlockDecomposition.BlockSolverInterface.set_sp_prio!
 BlockDecomposition.BlockSolverInterface.set_var_branching_prio!
 ```
 
+```@docs
+BlockDecomposition.BlockSolverInterface.set_branching_rules!
+```
+
 ## Additional data to the model
 
 ```@docs

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -21,3 +21,7 @@ branchingpriorityinmaster
 ```@docs
 branchingpriorityinsubproblem
 ```
+
+```@docs
+addbranching
+```

--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -8,7 +8,7 @@ We introduce them using the example of Generalized Assignment Problem.
 
 ## Introduction
 
-Cosider a set of machines `Machines = 1:M` and a set of jobs `Jobs = 1:J`.
+Consider a set of machines `Machines = 1:M` and a set of jobs `Jobs = 1:J`.
 A machine `m` has a resource capacity `Capacity[m]`. When we assign a job
 `j` to a machine `m`, the job has a cost `Cost[m,j]` and consumes
 `Weight[m,j]` resources of the machine `m`. The goal is to minimize the jobs

--- a/docs/src/callbacks.md
+++ b/docs/src/callbacks.md
@@ -21,13 +21,13 @@ gap = BlockModel(solver = solver)
 @variable(gap, x[m in Machines, j in Jobs], Bin)
 
 @constraint(gap, cov[0, j in Jobs],
-               sum{ x[m,j], m in Machines } >= 1)
+               sum(x[m,j] for m in Machines) >= 1)
 
 @constraint(gap, knp[m in Machines],
-               sum{Weight[m,j]*x[m,j], j in Jobs} <= Capacity[m])
+               sum(Weight[m,j]*x[m,j] for j in Jobs) <= Capacity[m])
 
 @objective(gap, Min,
-               sum{Cost[m,j]*x[m,j], m in Machines, j in Jobs})
+               sum(Cost[m,j]*x[m,j] for m in Machines, j in Jobs))
 
 function dw_fct(cstrname::Symbol, cstrid::Tuple) :: Tuple{Symbol, Tuple}
     if cstrname == :cov           # cov constraints will be assigned in the

--- a/src/BlockDecomposition.jl
+++ b/src/BlockDecomposition.jl
@@ -45,6 +45,7 @@ export  BlockModel,
         add_Benders_decomposition,
         addspmultiplicity,
         addsppriority,
+        addbranching,
         show
 
 # Oracles

--- a/src/BlockSolverInterface.jl
+++ b/src/BlockSolverInterface.jl
@@ -172,7 +172,14 @@ export getdisaggregatedvalueofvariable
     set_branching_rules!(s::AbstractMathProgSolver, rules::Dict{Symbol, Any})
 
 sends to the solver `s` a Dictionary `rules`. The key is the name of the branching rule
-and the content are the parameters. Names of branching rules depend on solvers.
+and the content is an array of branching instances. The array contains Tuple of variables name and parameters.
+Parameters are stored in an array of tuple (name_of_parameter, value_of_parameter).
+
+For instance,
+
+    rules = (:branching_rule_name => [(:x, [(:priority, 1)]), (:y, [(:priority, 1)])])
+
+Names of branching rules depend on solvers.
 """
 set_branching_rules!() = nothing
 export set_branching_rules!

--- a/src/BlockSolverInterface.jl
+++ b/src/BlockSolverInterface.jl
@@ -168,4 +168,12 @@ returns the disaggregated value of the `vcol` ``{}^{th}`` variable.
 getdisaggregatedvalueofvariable() = nothing
 export getdisaggregatedvalueofvariable
 
+"""
+    set_branching_rules!(s::AbstractMathProgSolver, rules::Dict{Symbol, Any})
+
+sends to the solver `s` a Dictionary `rules`. The key is the name of the branching rule
+and the content are the parameters. Names of branching rules depend on solvers.
+"""
+set_branching_rules!() = nothing
+export set_branching_rules!
 end

--- a/src/bjmodel.jl
+++ b/src/bjmodel.jl
@@ -37,6 +37,7 @@ function BlockModel(;solver = JuMP.UnsetSolver())
   m.ext[:objective_data] = ObjectiveData(NaN, -Inf, Inf)
 
   m.ext[:var_branch_prio_dict] = Dict{Tuple{Symbol, Tuple, Symbol}, Cdouble}() # (varname, sp, where) => (priority)
+  m.ext[:branching_rules] = Dict{Symbol, Any}()
 
   # Callbacks
   m.ext[:oracles] = Array{Tuple{Tuple, Symbol, Function}}(0)
@@ -141,9 +142,6 @@ create a branching rule named `rule` on variable `varname`. Agruments are provid
 by the used and store in a list of pair. Arguments are checked by the solver.
 """
 function addbranching(model::JuMP.Model, rule::Symbol, varname::Symbol; args...)
-  if !haskey(model.ext, :branching_rules)
-    model.ext[:branching_rules] = Dict{Symbol, Any}()
-  end
   if !haskey(model.ext[:branching_rules], rule)
     model.ext[:branching_rules][rule] = Vector{Tuple}()
   end

--- a/src/bjmodel.jl
+++ b/src/bjmodel.jl
@@ -139,7 +139,7 @@ end
     addbranching(model::JuMP.Model, rule::Symbol, varname::Symbol; args...)
 
 create a branching rule named `rule` on variable `varname`. Agruments are provided
-by the used and store in a list of pair. Arguments are checked by the solver.
+by the used and store in an array of pair. Arguments are checked by the solver.
 """
 function addbranching(model::JuMP.Model, rule::Symbol, varname::Symbol; args...)
   if !haskey(model.ext[:branching_rules], rule)

--- a/src/bjmodel.jl
+++ b/src/bjmodel.jl
@@ -133,3 +133,19 @@ end
 function addsppriority(m::JuMP.Model, sp_prio)
   m.ext[:sp_prio_fct] = sp_prio
 end
+
+"""
+    addbranching(model::JuMP.Model, rule::Symbol, varname::Symbol; args...)
+
+create a branching rule named `rule` on variable `varname`. Agruments are provided
+by the used and store in a list of pair. Arguments are checked by the solver.
+"""
+function addbranching(model::JuMP.Model, rule::Symbol, varname::Symbol; args...)
+  if !haskey(model.ext, :branching_rules)
+    model.ext[:branching_rules] = Dict{Symbol, Any}()
+  end
+  if !haskey(model.ext[:branching_rules], rule)
+    model.ext[:branching_rules][rule] = Vector{Tuple}()
+  end
+  push!(model.ext[:branching_rules][rule], (varname, args))
+end

--- a/src/bjsolve.jl
+++ b/src/bjsolve.jl
@@ -24,6 +24,8 @@ function bj_solve(model;
   send_to_solver!(model, set_var_branching_prio!, :var_branch_prio_dict, false)
   # Oracles
   send_to_solver!(model, set_oracles!, :oracles, false)
+  # Branching rules
+  send_to_solver!(model, set_branching_rules!, :branching_rules, false)
 
   if applicable(send_extras!, model) # works with BlockDecompositionExtras
     send_extras!(model)


### PR DESCRIPTION
A new method to add generic branching rules to the model.
Branching rules are processed by the solver.

For instance, I add a branching rule named `:subprob_variable` on variable `y` with the argument `priority` equals 0.5.
```julia
addbranching(model, :subprob_variable, :y, priority = 0.5)
```
These information are send to the solver. If the branching rules is not supported, the solver must throw an error. 